### PR TITLE
Update config_example.php

### DIFF
--- a/configs/config_example.php
+++ b/configs/config_example.php
@@ -47,8 +47,8 @@ $cfg['passwd_encryption'] = "SHA1";
 $cfg['min_passwd_length'] = "6";
 $cfg['max_userid_length'] = "32";
 $cfg['max_groupname_length'] = "32";
-$cfg['userid_regex']    = "/^([a-z][a-z0-9_.\-]{0,32})$/i"; //every username must comply with this regex
-$cfg['groupname_regex'] = "/^([a-z][a-z0-9_.\-]{0,32})$/i"; //every username must comply with this regex
+$cfg['userid_regex']    = "/^([a-z][a-z0-9_\.\-]{0,32})$/i"; //every username must comply with this regex
+$cfg['groupname_regex'] = "/^([a-z][a-z0-9_\.\-]{0,32})$/i"; //every username must comply with this regex
 
 // next option activates a userid filter on users.php. Usefull if you want to manage a lot of users
 // that have a prefix like "pre-username", the first occurence of separator is recognized only!

--- a/configs/config_example.php
+++ b/configs/config_example.php
@@ -45,10 +45,10 @@ $cfg['default_homedir'] = "/srv/ftp";
 // "pbkdf2" is supported if you are using ProFTPd 1.3.5.
 $cfg['passwd_encryption'] = "SHA1";
 $cfg['min_passwd_length'] = "6";
-$cfg['max_userid_length'] = "20";
-$cfg['max_groupname_length'] = "20";
-$cfg['userid_regex']    = "/^([a-z][a-z0-9_\-]{0,20})$/i"; //every username must comply with this regex
-$cfg['groupname_regex'] = "/^([a-z][a-z0-9_\-]{0,20})$/i"; //every username must comply with this regex
+$cfg['max_userid_length'] = "32";
+$cfg['max_groupname_length'] = "32";
+$cfg['userid_regex']    = "/^([a-z][a-z0-9_.\-]{0,32})$/i"; //every username must comply with this regex
+$cfg['groupname_regex'] = "/^([a-z][a-z0-9_.\-]{0,32})$/i"; //every username must comply with this regex
 
 // next option activates a userid filter on users.php. Usefull if you want to manage a lot of users
 // that have a prefix like "pre-username", the first occurence of separator is recognized only!

--- a/tables-sqlite3.sql
+++ b/tables-sqlite3.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `groups` (
-  `groupname` VARCHAR(16) UNIQUE NOT NULL default '',
+  `groupname` VARCHAR(32) UNIQUE NOT NULL default '',
   `gid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
   `members` VARCHAR(255) NOT NULL default ''
 );

--- a/tables.sql
+++ b/tables.sql
@@ -3,7 +3,7 @@
 #
 
 CREATE TABLE `groups` (
-  `groupname` varchar(16) NOT NULL default '',
+  `groupname` varchar(32) NOT NULL default '',
   `gid` smallint(6) unsigned NOT NULL auto_increment,
   `members` varchar(255) NOT NULL default '',
   PRIMARY KEY  (`gid`),


### PR DESCRIPTION
Increasing the length of a user name and user group name up to 32 characters. Permission to use the point in the user name and the name of the user group.
