### PR TITLE
Edit user additional group error

### DIFF
--- a/includes/AdminClass.php
+++ b/includes/AdminClass.php
@@ -468,7 +468,7 @@ class AdminClass {
     }
 
     /**
-     * Adds a user to a group using the groupid, does not check if user is already a member!
+     * Adds a user to a group using the groupid
      * @param Integer $userid
      * @param Integer $gid
      * @return boolean false on error
@@ -479,13 +479,13 @@ class AdminClass {
         $query = sprintf($format, $this->config['field_members'], $this->config['table_groups'], $this->config['field_gid'], $gid);
         $result = $this->dbConn->get_var($query);
         if ($result != "") {
-                if(strpos($result, $userid) !== false) {
-                        return true;
-                } else {
-            		$members = $result.','.$userid;
-		}
+            if(strpos($result, $userid) !== false) {
+                return true;
+            } else {
+                $members = $result.','.$userid;
+            }
         } else {
-        	$members = $userid;
+            $members = $userid;
         }
 
         $format = 'UPDATE %s SET %s="%s" WHERE %s="%s"';
@@ -507,8 +507,8 @@ class AdminClass {
         $query = sprintf($format, $this->config['field_members'], $this->config['table_groups'], $this->config['field_gid'], $gid);
         $result = $this->dbConn->get_var($query);
         if(strpos($result, $userid) === false) {
-		return true;
-	}
+            return true;
+        }
         $members_array = explode(",", $result);
         $members_new_array = array_diff($members_array, array("$userid", ""));
         if (is_array($members_new_array)) {

--- a/includes/AdminClass.php
+++ b/includes/AdminClass.php
@@ -479,9 +479,13 @@ class AdminClass {
         $query = sprintf($format, $this->config['field_members'], $this->config['table_groups'], $this->config['field_gid'], $gid);
         $result = $this->dbConn->get_var($query);
         if ($result != "") {
-            $members = $result.','.$userid;
+                if(strpos($result, $userid) !== false) {
+                        return true;
+                } else {
+            		$members = $result.','.$userid;
+		}
         } else {
-            $members = $userid;
+        	$members = $userid;
         }
 
         $format = 'UPDATE %s SET %s="%s" WHERE %s="%s"';
@@ -502,6 +506,9 @@ class AdminClass {
         $format = 'SELECT %s FROM %s WHERE %s="%s"';
         $query = sprintf($format, $this->config['field_members'], $this->config['table_groups'], $this->config['field_gid'], $gid);
         $result = $this->dbConn->get_var($query);
+        if(strpos($result, $userid) === false) {
+		return true;
+	}
         $members_array = explode(",", $result);
         $members_new_array = array_diff($members_array, array("$userid", ""));
         if (is_array($members_new_array)) {

--- a/remove_user.php
+++ b/remove_user.php
@@ -41,7 +41,7 @@ if (empty($errormsg) && !empty($_REQUEST["action"]) && $_REQUEST["action"] == "r
   $groups = $ac->get_groups();
   while (list($g_gid, $g_group) = each($groups)) {
     if (!$ac->remove_user_from_group($userid, $g_gid)) {
-      $errormsg = 'Cannot remove user "'.$userid.'" from group "'.$ggroup.'"; see log files for more information.';
+      $errormsg = 'Cannot remove user "'.$userid.'" from group "'.$g_group.'"; see log files for more information.';
       break;
     }
   }


### PR DESCRIPTION
Hi,
sorry first PL I do so I may not do that quite well ^^
Here's a bugfix when you edit a user. Actually when you try to edit a user, it removes additional members from a group to add them again when you submit the form. Problem is that it's performing it on every group ! So if the current user is not within every group, it will try to remove it from every group too. But then when doing the update, MySQL will return 0 and so the form won't validate.This version simply checks wether you can add/remove an additional group. I guess the most correct way to do it would be to simply update groups where the current user is and not all groups.
Let me know.