### PR TITLE
Make default shell configurable

### DIFF
--- a/add_user.php
+++ b/add_user.php
@@ -145,7 +145,7 @@ if (isset($errormsg)) {
   if (empty($infomsg)) {
     $ugid   = "";
     $ad_gid = array();
-    $shell  = "/bin/false";
+    $shell  = $cfg['default_shell'];
   } else {
     $ugid    = $_REQUEST[$field_ugid];
     $ad_gid = $_REQUEST[$field_ad_gid];

--- a/configs/config_example.php
+++ b/configs/config_example.php
@@ -41,6 +41,9 @@ $cfg['field_members'] = "members";
 
 $cfg['default_uid'] = ""; //if empty next incremental will be default
 $cfg['default_homedir'] = "/srv/ftp";
+// For sftp enabled servers install and use something like scponly or rssh shell
+$cfg['default_shell'] = "/bin/false"; 
+
 // Use either SHA1 or MD5 or any other supported by your MySQL-Server and ProFTPd
 // "pbkdf2" is supported if you are using ProFTPd 1.3.5.
 // "crypt" uses the unix crypt() function.


### PR DESCRIPTION
Make default shell configurable.
For s/ftp enabled installations login is not possible with /bin/false as shell. 
Hence this change allows admins to configure fx. scponly or rssh shells as default shell.
