### PR TITLE
Fix allowed min datetime range on dateime fields

### DIFF
--- a/001-fix-cant-delete-users.patch
+++ b/001-fix-cant-delete-users.patch
@@ -1,0 +1,52 @@
+diff --git "a/includes/AdminClass.php" "b/includes/AdminClass.php"
+index 98b4a4e..a448068 100644
+--- "a/includes/AdminClass.php"
++++ "b/includes/AdminClass.php"
+@@ -483,7 +483,8 @@ class AdminClass {
+         $query = sprintf($format, $this->config['field_members'], $this->config['table_groups'], $this->config['field_gid'], $gid);
+         $result = $this->dbConn->get_var($query);
+         if ($result != "") {
+-            if(strpos($result, $userid) !== false) {
++            $resultMembers = explode(',', $result);
++            if(in_array($userid, $resultMembers, true)) {
+                 return true;
+             } else {
+                 $members = $result.','.$userid;
+@@ -507,13 +508,17 @@ class AdminClass {
+      */
+     function remove_user_from_group($userid, $gid) {
+         if (empty($userid) || empty($gid)) return false;
+-        $format = 'SELECT %s FROM %s WHERE %s="%s"';
+-        $query = sprintf($format, $this->config['field_members'], $this->config['table_groups'], $this->config['field_gid'], $gid);
+-        $result = $this->dbConn->get_var($query);
+-        if(strpos($result, $userid) === false) {
++        $formatSelect = 'SELECT %s FROM %s WHERE %s="%s"';
++        $querySelect = sprintf($formatSelect, $this->config['field_members'], $this->config['table_groups'], $this->config['field_gid'], $gid);
++        $resultSelect = $this->dbConn->get_var($querySelect);
++        // strpos is uneffective with same username beginnings
++        // eg. test => test_
++        $resultMembers = explode(',', $resultSelect);
++        if(!in_array($userid, $resultMembers, true)) {
+             return true;
+         }
+-        $members_array = explode(",", $result);
++
++        $members_array = explode(",", $resultSelect);
+         $members_new_array = array_diff($members_array, array("$userid", ""));
+         if (is_array($members_new_array)) {
+             $members_new = implode(",", $members_new_array);
+@@ -521,10 +526,10 @@ class AdminClass {
+             $members_new = "";
+         }
+ 
+-        $format = 'UPDATE %s SET %s="%s" WHERE %s="%s"';
+-        $query = sprintf($format, $this->config['table_groups'], $this->config['field_members'], $members_new, $this->config['field_gid'], $gid);
+-        $result = $this->dbConn->query($query);
+-        if (!$result) return false;
++        $formatUpdate = 'UPDATE %s SET %s="%s" WHERE %s="%s"';
++        $queryUpdate = sprintf($formatUpdate, $this->config['table_groups'], $this->config['field_members'], $members_new, $this->config['field_gid'], $gid);
++        $resultUpdate = $this->dbConn->query($queryUpdate);
++        if (!$resultUpdate) return false;
+         return true;
+     }
+ 

--- a/002-fix-sql-datetime-default-range.patch
+++ b/002-fix-sql-datetime-default-range.patch
@@ -1,0 +1,15 @@
+diff --git "a/tables.sql" "b/tables.sql"
+index b141835..0fa6c9b 100644
+--- "a/tables.sql"
++++ "b/tables.sql"
+@@ -33,8 +33,8 @@ CREATE TABLE `users` (
+   `files_in_used` bigint(20) unsigned NOT NULL default '0',
+   `files_out_used` bigint(20) unsigned NOT NULL default '0',
+   `login_count` int(11) unsigned NOT NULL default '0',
+-  `last_login` datetime NOT NULL default '0000-00-00 00:00:00',
+-  `last_modified` datetime NOT NULL default '0000-00-00 00:00:00',
++  `last_login` datetime NOT NULL default '1000-01-01 00:00:00',
++  `last_modified` datetime NOT NULL default '1000-01-01 00:00:00',
+   PRIMARY KEY  (`id`),
+   UNIQUE KEY `userid` (`userid`)
+ ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_general_ci COMMENT='ProFTPd user table';

--- a/tables.sql
+++ b/tables.sql
@@ -33,8 +33,8 @@ CREATE TABLE `users` (
   `files_in_used` bigint(20) unsigned NOT NULL default '0',
   `files_out_used` bigint(20) unsigned NOT NULL default '0',
   `login_count` int(11) unsigned NOT NULL default '0',
-  `last_login` datetime NOT NULL default '0000-00-00 00:00:00',
-  `last_modified` datetime NOT NULL default '0000-00-00 00:00:00',
+  `last_login` datetime NOT NULL default '1000-01-01 00:00:00',
+  `last_modified` datetime NOT NULL default '1000-01-01 00:00:00',
   PRIMARY KEY  (`id`),
   UNIQUE KEY `userid` (`userid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_general_ci COMMENT='ProFTPd user table';


### PR DESCRIPTION
Hi,

I have installed ProFTPd-Admin on my current MariaDB 10.4.20 (bundled with XAMPP and PHP 7.4).
But importing the `table.sql` as mentioned in the installation guide the database will reject the import due to wrong default dateime value.

From the MariaDB knowledge base
> MariaDB stores values that use the DATETIME data type in a format that supports values between 1000-01-01 00:00:00.000000 and 9999-12-31 23:59:59.999999

The default settings are to not have ` NO_ZERO_DATE` set.
So I think it is useful to arrange that here.

Feel free to accept the PR :)

regards
Sven