### PR TITLE
Fix allowed min datetime range on dateime fields

### DIFF
--- a/tables.sql
+++ b/tables.sql
@@ -33,8 +33,8 @@ CREATE TABLE `users` (
   `files_in_used` bigint(20) unsigned NOT NULL default '0',
   `files_out_used` bigint(20) unsigned NOT NULL default '0',
   `login_count` int(11) unsigned NOT NULL default '0',
-  `last_login` datetime NOT NULL default '0000-00-00 00:00:00',
-  `last_modified` datetime NOT NULL default '0000-00-00 00:00:00',
+  `last_login` datetime NOT NULL default '1000-01-01 00:00:00',
+  `last_modified` datetime NOT NULL default '1000-01-01 00:00:00',
   PRIMARY KEY  (`id`),
   UNIQUE KEY `userid` (`userid`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1 COLLATE=latin1_general_ci COMMENT='ProFTPd user table';


### PR DESCRIPTION
Hi,

I have installed ProFTPd-Admin on my current MariaDB 10.4.20 (bundled with XAMPP and PHP 7.4).
But importing the `table.sql` as mentioned in the installation guide the database will reject the import due to wrong default dateime value.

From the MariaDB knowledge base
> MariaDB stores values that use the DATETIME data type in a format that supports values between 1000-01-01 00:00:00.000000 and 9999-12-31 23:59:59.999999

The default settings are to not have ` NO_ZERO_DATE` set.
So I think it is useful to arrange that here.

Feel free to accept the PR :)

regards
Sven