### PR TITLE
Add more stricter user existence condition instead of strpos checks

### DIFF
--- a/includes/AdminClass.php
+++ b/includes/AdminClass.php
@@ -483,7 +483,8 @@ class AdminClass {
         $query = sprintf($format, $this->config['field_members'], $this->config['table_groups'], $this->config['field_gid'], $gid);
         $result = $this->dbConn->get_var($query);
         if ($result != "") {
-            if(strpos($result, $userid) !== false) {
+            $resultMembers = explode(',', $result);
+            if(in_array($userid, $resultMembers, true)) {
                 return true;
             } else {
                 $members = $result.','.$userid;
@@ -510,7 +511,8 @@ class AdminClass {
         $format = 'SELECT %s FROM %s WHERE %s="%s"';
         $query = sprintf($format, $this->config['field_members'], $this->config['table_groups'], $this->config['field_gid'], $gid);
         $result = $this->dbConn->get_var($query);
-        if(strpos($result, $userid) === false) {
+        $resultMembers = explode(',', $result);
+        if(!in_array($userid, $resultMembers, true)) {
             return true;
         }
         $members_array = explode(",", $result);


### PR DESCRIPTION
Hi,

the check with `strpos` could be falsy if username have the same beginning: `test`, `test_1`, `test_2` etc.
So I have added a stricter method for checking those.

regards,
Sven